### PR TITLE
Allow to change bar anchor points

### DIFF
--- a/CastBarTemplate.lua
+++ b/CastBarTemplate.lua
@@ -370,7 +370,7 @@ function CastBarTemplate:ApplySettings()
 	if not db.x then
 		db.x = (UIParent:GetWidth() / 2 - (db.w * db.scale) / 2) / db.scale
 	end
-	self:SetPoint("BOTTOMLEFT", UIParent, "BOTTOMLEFT", db.x, db.y)
+	self:SetPoint(db.barAnchor, UIParent, db.screenAnchor, db.x, db.y)
 	self:SetWidth(db.w + 10)
 	self:SetHeight(db.h + 10)
 	self:SetAlpha(db.alpha)
@@ -534,9 +534,33 @@ do
 		self:StartMoving()
 	end
 
+	local function getpoint(frame, point)
+		if point == "TOP" then
+			return frame:GetLeft() + frame:GetWidth() / 2, frame:GetTop()
+		elseif point == "RIGHT" then
+			return frame:GetRight(), frame:GetBottom() + frame:GetHeight() / 2
+		elseif point == "BOTTOM" then
+			return frame:GetLeft() + frame:GetWidth() / 2, frame:GetBottom()
+		elseif point == "LEFT" then
+			return frame:GetLeft(), frame:GetBottom() + frame:GetHeight() / 2
+		elseif point == "TOPRIGHT" then
+			return frame:GetRight(), frame:GetTop()
+		elseif point == "TOPLEFT" then
+			return frame:GetLeft(), frame:GetTop()
+		elseif point == "BOTTOMLEFT" then
+			return frame:GetLeft(), frame:GetBottom()
+		elseif point == "BOTTOMRIGHT" then
+			return frame:GetRight(), frame:GetBottom()
+		elseif point == "CENTER" then
+			return frame:GetCenter()
+		end
+	end
+
 	local function dragstop(self)
-		self.config.x = self:GetLeft()-UIParent:GetLeft()
-		self.config.y = self:GetBottom()-UIParent:GetBottom()
+		local parent_x, parent_y = getpoint(UIParent, self.config.screenAnchor)
+		local bar_x, bar_y = getpoint(self, self.config.barAnchor)
+		self.config.x = bar_x - parent_x
+		self.config.y = bar_y - parent_y
 		self:StopMovingOrSizing()
 	end
 
@@ -715,6 +739,38 @@ do
 					isPercent = true,
 					min = 0.1, max = 1, bigStep = 0.025,
 					order = 202,
+				},
+				screenAnchor = {
+					type = "select",
+					name = L["Anchor point"],
+					values = {
+						["TOP"] = L["Top"],
+						["RIGHT"] = L["Right"],
+						["BOTTOM"] = L["Bottom"],
+						["LEFT"] = L["Left"],
+						["TOPRIGHT"] = L["Top Right"],
+						["TOPLEFT"] = L["Top Left"],
+						["BOTTOMLEFT"] = L["Bottom Left"],
+						["BOTTOMRIGHT"] = L["Bottom Right"],
+						["CENTER"] = L["Center"]
+					},
+					order = 203,
+				},
+				barAnchor = {
+					type = "select",
+					name = L["Relative point"],
+					values = {
+						["TOP"] = L["Top"],
+						["RIGHT"] = L["Right"],
+						["BOTTOM"] = L["Bottom"],
+						["LEFT"] = L["Left"],
+						["TOPRIGHT"] = L["Top Right"],
+						["TOPLEFT"] = L["Top Left"],
+						["BOTTOMLEFT"] = L["Bottom Left"],
+						["BOTTOMRIGHT"] = L["Bottom Right"],
+						["CENTER"] = L["Center"]
+					},
+					order = 204,
 				},
 				icon = {
 					type = "header",
@@ -980,6 +1036,8 @@ Quartz3.CastBarTemplate.defaults = {
 	texture = "Blizzard",
 	hideicon = false,
 	alpha = 1,
+	screenAnchor = "BOTTOMLEFT",
+	barAnchor = "BOTTOMLEFT",
 	iconalpha = 0.9,
 	iconposition = "left",
 	icongap = 1,

--- a/locale/enUS.lua
+++ b/locale/enUS.lua
@@ -10,3 +10,6 @@ debug = true
 local L = LibStub("AceLocale-3.0"):NewLocale("Quartz3", "enUS", true, debug)
 
 --@localization(locale="enUS", format="lua_additive_table", same-key-is-true=true)@
+
+L["Anchor point"] = true
+L["Relative point"] = true

--- a/locale/ruRU.lua
+++ b/locale/ruRU.lua
@@ -6,3 +6,6 @@ local L = LibStub("AceLocale-3.0"):NewLocale("Quartz3", "ruRU")
 if not L then return end
 
 --@localization(locale="ruRU", format="lua_additive_table", handle-unlocalized="ignore")@
+
+L["Anchor point"] = "Точка привязки"
+L["Relative point"] = "Относительно точки"


### PR DESCRIPTION
I usually play in windowed mode and change size of the window sometimes. But after each resize I had to open the setting menu and change positions of castbars.
Now I can anchor castbars to different sides of the window (center usually). And after window resizing castbars stay ot heir positions and look well.