### PR TITLE
Added a Target Name Style option to the Player module

### DIFF
--- a/CastBarTemplate.lua
+++ b/CastBarTemplate.lua
@@ -133,7 +133,11 @@ end
 
 function CastBarTemplate:SetNameText(name)
 	if self.config.targetname and self.targetName and self.targetName ~= "" then
-		self.Text:SetFormattedText("%s -> %s", name, self.targetName)
+		if self.config.targetnamestyle == "on" then
+			self.Text:SetFormattedText("%s on %s", name, self.targetName)
+		else
+			self.Text:SetFormattedText("%s -> %s", name, self.targetName)
+		end
 	else
 		self.Text:SetText(name)
 	end

--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -41,6 +41,7 @@ local defaults = {
 		noInterruptBorderChange = false,
 		noInterruptColorChange = false,
 		noInterruptShield = false,
+		targetnamestyle = "default"
 	})
 }
 
@@ -72,6 +73,14 @@ do
 				name = L["Show Target Name"],
 				desc = L["Display target name of spellcasts after spell name"],
 				disabled = function() return db.hidenametext end,
+				order = 402,
+			}
+			options.args.targetnamestyle = {
+				type = "select",
+				name = L["Target Name Style"],
+				desc = L["How to display target name of spellcasts after spell name"],
+				values = {["default"] = L["Spell -> Target"], ["on"] = L["Spell on Target"]},
+				disabled = function() return not db.targetname or db.hidenametext end,
 				order = 402,
 			}
 			options.args.noInterruptGroup = nil


### PR DESCRIPTION
Added a Target Name Style option to the Player module, which allows the player to choose between the current default 'Spell -> Target' style when showing the target name in the cast bar and a new 'Spell on Target' style.

Here's the new Options UI with the dropdown for the Target Name Style:
![Options UI](https://user-images.githubusercontent.com/42030/104001689-dfdf7b00-5154-11eb-870c-1f9027df862e.png)


Here's how the new 'Spell on Target' style option appears when casting a spell:
![New Spell on Target Style](https://user-images.githubusercontent.com/42030/104001623-ca6a5100-5154-11eb-8275-8d86933bb308.png)

And here's the existing, default 'Spell -> Target' style for reference:
![Current Style](https://user-images.githubusercontent.com/42030/104001683-de15b780-5154-11eb-9b62-30762a93d407.png)


