### PR TITLE
Fix TBC priest error

### DIFF
--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -95,14 +95,13 @@ end
 
 
 function Player:OnEnable()
-	if not WoWBC then
-		self:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED", "UpdateChannelingTicks")
-	end
-
 	self.Bar:RegisterEvents()
 	self:ApplySettings()
 
-	self:UpdateChannelingTicks()
+	if not WoWBC then
+		self:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED", "UpdateChannelingTicks")
+		self:UpdateChannelingTicks()
+	end
 end
 
 function Player:OnDisable()


### PR DESCRIPTION
Fixes error:

```
Quartz\modules\Player-Player.lua:230: attempt to call global 'GetActiveSpecGroup' (a nil value)
```

Reported at: https://www.curseforge.com/wow/addons/quartz?comment=3019

I assume this only affects priests in TBC, since the call to `GetTalentInfoByID` is guarded by the condition at...

https://github.com/Nevcairiel/Quartz/blob/7211fe49418ffc341bb85b5070985a75b8109353/modules/Player.lua#L235