### PR TITLE
Fix bug in burning crusade

### DIFF
--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -102,7 +102,9 @@ function Player:OnEnable()
 	self.Bar:RegisterEvents()
 	self:ApplySettings()
 
-	self:UpdateChannelingTicks()
+	if not WoWBC then
+		self:UpdateChannelingTicks()
+	end
 end
 
 function Player:OnDisable()


### PR DESCRIPTION
GetActiveSpecGroup() does not work in Burning Crusade.  You wrapped the registration above but failed to wrap the method that calls it directly.