### PR TITLE
Add channeling to Mage and Priest BCC spells

### DIFF
--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -196,8 +196,16 @@ local function setBarTicks(ticknum, duration, ticks)
 	end
 end
 
-local channelingTicks = WoWBC and {} or
-{
+local channelingTicks = WoWBC and {
+	--- BCC
+	-- mage
+	[GetSpellInfo(5143)] = 5,  -- Arcane Missiles
+	[GetSpellInfo(12051)] = 4, -- Evocation
+	[GetSpellInfo(10)] = 8,    -- Blizzard
+	-- priest
+	[GetSpellInfo(15407)] = 3, -- Mind Flay
+} or {
+	--- Retail
 	-- warlock
 	[GetSpellInfo(234153)] = 5, -- drain life
 	[GetSpellInfo(198590)] = 5, -- drain soul


### PR DESCRIPTION
This PR adds some channeling ticks to Mage and Priest BCC spells

I don't have other classes to test with right now, but if required I'd be down to get friends to help out to fill out the data for the rest of the classes.

## Priest

- [x] Mind Flay

## Mage

- [x] Evocation (does not support mage 2-pc t6)
- [x] Blizzard
- [x] Arcane Missiles

## Warlock

- [ ] Rain of Fire (4 ticks?)
- [ ] Hellfire (15 ticks?)
- [ ] Drain Life (5 ticks?)
- [ ] Drain Mana (5 ticks?)
- [ ] Drain Soul (5 ticks?)
- [ ] Health Funnel (10 ticks?)

## Druid

- [ ] Tranquility (4 ticks?)
- [ ] Hurricane (10 ticks?)

## Hunter

- [ ] Volley (6 ticks?)

List fetched from https://tbc.wowhead.com/spells/abilities?filter=27:10;1:1;0:0

Fixes #38