### PR TITLE
Fix missing channeling ticks

### DIFF
--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -164,11 +164,11 @@ end
 
 local sparkfactory = {
 	__index = function(t,k)
-		local spark = castBar:CreateTexture(nil, 'OVERLAY')
+		local spark = castBar:CreateTexture(nil, "OVERLAY")
 		t[k] = spark
 		spark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark")
 		spark:SetVertexColor(unpack(Quartz3.db.profile.sparkcolor))
-		spark:SetBlendMode('ADD')
+		spark:SetBlendMode("ADD")
 		spark:SetWidth(20)
 		spark:SetHeight(db.h*2.2)
 		return spark


### PR DESCRIPTION
I don't know enough LUA to explain why this is working, but changing the single-quotes to double-quotes made the channeling ticks show up again for me.