### PR TITLE
Fix registration of retail events for tbcc

### DIFF
--- a/modules/Focus.lua
+++ b/modules/Focus.lua
@@ -140,8 +140,10 @@ function Focus:ApplySettings()
 		FocusFrameSpellBar:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
 		FocusFrameSpellBar:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
 		FocusFrameSpellBar:RegisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE")
-		FocusFrameSpellBar:RegisterEvent("UNIT_SPELLCAST_INTERRUPTIBLE")
-		FocusFrameSpellBar:RegisterEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE")
+		if WoWRetail then
+			FocusFrameSpellBar:RegisterEvent("UNIT_SPELLCAST_INTERRUPTIBLE")
+			FocusFrameSpellBar:RegisterEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE")
+		end
 		FocusFrameSpellBar:RegisterEvent("PLAYER_ENTERING_WORLD")
 		FocusFrameSpellBar:RegisterEvent("PLAYER_FOCUS_CHANGED")
 		FocusFrameSpellBar:RegisterEvent("CVAR_UPDATE")


### PR DESCRIPTION
UNIT_SPELLCAST_INTERRUPTIBLE and UNIT_SPELLCAST_NOT_INTERRUPTIBLE are only available for retail, thus a version check should be performed to prevent lua errors.