### PR TITLE
Add strata option to Player, Target, Pet, and Focus bars.

### DIFF
--- a/CastBarTemplate.lua
+++ b/CastBarTemplate.lua
@@ -408,6 +408,8 @@ function CastBarTemplate:ApplySettings()
 
 	LibWindow.RestorePosition(self)
 
+	self:SetFrameStrata(db.strata)
+
 	ToggleCastNotInterruptible(self, self.lastNotInterruptible, true)
 
 	local iconwidth = db.h + db.icongap
@@ -785,6 +787,26 @@ do
 					},
 					order = 205,
 				},
+				strata = {
+					type = "select",
+					name = L["Strata"],
+					desc = L["Set the bar in front of or behind other UI elements."],
+					values = {
+						["BACKGROUND"] = L["BACKGROUND"],
+						["MEDIUM"] = L["MEDIUM"],
+						["HIGH"] = L["HIGH"],
+						["DIALOG"] = L["DIALOG"],
+						["TOOLTIP"] = L["TOOLTIP"]
+					},
+					sorting = {
+						"BACKGROUND",
+						"MEDIUM",
+						"HIGH",
+						"DIALOG",
+						"TOOLTIP"
+					},
+					order = 206,
+				},
 				icon = {
 					type = "header",
 					name = L["Icon"],
@@ -1044,6 +1066,7 @@ Quartz3.CastBarTemplate.defaults = {
 	--x =  -- applied automatically in applySettings()
 	y = 180,
 	point = "BOTTOMLEFT",
+	strata = "MEDIUM",
 	h = 25,
 	w = 250,
 	scale = 1,
@@ -1091,7 +1114,6 @@ function Quartz3.CastBarTemplate:new(parent, unit, name, localizedName, config)
 
 	Quartz3.CastBarTemplate.bars[name] = bar
 
-	bar:SetFrameStrata("MEDIUM")
 	bar:SetScript("OnShow", OnShow)
 	bar:SetScript("OnHide", OnHide)
 	bar:SetScript("OnUpdate", OnUpdate)


### PR DESCRIPTION
I've been wanting the ability to change the frame strata of the Quartz bars so the times when UI overlaps them (such as when depositing Anima) I can still see the bar and time left. I noticed #17 was looking for the same thing so I tried my hand at figuring it out.

In the included commit I added an option to the the CastBarTemplate for choosing a strata (from a list) and set the default to MEDIUM (effectively the same as in the current version). Through my limited testing, I believe these changes will be invisible to an upgrading user and will only impact them if they go into the Options screen and change it themselves. Each bar can have its own strata setting and changing one will leave the others as default (Medium).

I _believe_ all the text is properly localizable but I'm not sure if anything else needs to be done for the build process. If something obvious is missing or broken, let me know and I can try to work it and and update this request.

Thanks,
Peter!