### PR TITLE
Add ticks for priest's spells on WotLK

### DIFF
--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -224,6 +224,10 @@ local channelingTicks = WoWWrath and {
 	[GetSpellInfo(5145)] = 5, -- arcane missiles
 	-- priest
 	[GetSpellInfo(15407)] = 3, -- mind flay
+	[GetSpellInfo(48045)] = 5, -- mind sear
+	[GetSpellInfo(47540)] = 2, -- penance
+	[GetSpellInfo(64843)] = 4, -- divine hymn
+	[GetSpellInfo(64901)] = 4, -- hymn of hope
 	-- warlock
 	[GetSpellInfo(1949)] = 15, -- hellfire
 	[GetSpellInfo(5740)] = 4, -- rain of fire


### PR DESCRIPTION
Mind Sear ticks are currently missing for priests on WotLK, this PR adds them