### PR TITLE
Fixing missing ticks on Cataclysm Prepatch

### DIFF
--- a/CastBarTemplate.lua
+++ b/CastBarTemplate.lua
@@ -24,6 +24,7 @@ local media = LibStub("LibSharedMedia-3.0")
 local lsmlist = AceGUIWidgetLSMlists
 
 local WoWRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
+local WoWCata = (WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC)
 local WoWWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC)
 local WoWClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
 
@@ -236,7 +237,7 @@ function CastBarTemplate:UNIT_SPELLCAST_START(event, unit, guid, spellID)
 	if not startTime or not endTime then return end
 
 	-- this property doesn't exist in BC, and aliases with the spellID
-	if not WoWRetail and not WoWWrath then
+	if not WoWRetail and not WoWWrath and not WoWCata then
 		notInterruptible = false
 	end
 

--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -28,6 +28,7 @@ local WOW_INTERFACE_VER = select(4, GetBuildInfo())
 local WoWRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
 local WoWBC = (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE) and WOW_INTERFACE_VER >= 20500 and WOW_INTERFACE_VER < 30000
 local WoWWrath = (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE) and WOW_INTERFACE_VER >= 30400 and WOW_INTERFACE_VER < 40000
+local WoWCata = (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE) and WOW_INTERFACE_VER >= 40400 and WOW_INTERFACE_VER < 50000
 
 ----------------------------
 -- Upvalues
@@ -269,6 +270,26 @@ local channelingTicks = WoWWrath and {
 	[GetSpellInfo(1949)] = 15, -- hellfire
 	[GetSpellInfo(5740)] = 4, -- rain of fire
 	[GetSpellInfo(5138)] = 5, -- drain mana
+	[GetSpellInfo(689)] = 5, -- drain life
+	[GetSpellInfo(1120)] = 5, -- drain soul
+	[GetSpellInfo(755)] = 10, -- health funnel
+} or WoWCata and {
+	--- Wrath
+	-- druid
+	[GetSpellInfo(740)] = 4, -- tranquility
+	[GetSpellInfo(16914)] = 10, -- hurricane
+	-- mage
+	[GetSpellInfo(10)] = 8, -- blizzard
+	[GetSpellInfo(5143)] = 5, -- arcane missiles
+	-- priest
+	[GetSpellInfo(15407)] = 3, -- mind flay
+	[GetSpellInfo(48045)] = 5, -- mind sear
+	[GetSpellInfo(47540)] = 2, -- penance
+	[GetSpellInfo(64843)] = 4, -- divine hymn
+	[GetSpellInfo(64901)] = 4, -- hymn of hope
+	-- warlock
+	[GetSpellInfo(1949)] = 15, -- hellfire
+	[GetSpellInfo(5740)] = 4, -- rain of fire
 	[GetSpellInfo(689)] = 5, -- drain life
 	[GetSpellInfo(1120)] = 5, -- drain soul
 	[GetSpellInfo(755)] = 10, -- health funnel


### PR DESCRIPTION
Ticks on channeled spells were missing. There were still old Spell-IDs in _channelingTicks_ which are now deprecated. Creating a seperate case for Cataclysm and removing the obsolete Spells fixes this.