### PR TITLE
Prevent `C_TradeSkillUI.CraftRecipe` error in Cataclysm Classic

### DIFF
--- a/modules/Tradeskill.lua
+++ b/modules/Tradeskill.lua
@@ -97,7 +97,7 @@ function Tradeskill:OnEnable()
 		else
 			self:RegisterEvent("ADDON_LOADED")
 		end
-	elseif C_TradeSkillUI then
+	elseif C_TradeSkillUI and C_TradeSkillUI.CraftRecipe then
 		self:SecureHook(C_TradeSkillUI, "CraftRecipe", "DoTradeSkillClassic")
 	else
 		self:SecureHook("DoTradeSkill", "DoTradeSkillClassic")


### PR DESCRIPTION
Check for `C_TradeSkillUI.CraftRecipe` before trying to hook it, since Cataclysm Classic has `C_TradeSkillUI` but does not have `C_TradeSkillUI.CraftRecipe`.