### PR TITLE
Update retail channeling ticks

### DIFF
--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -344,25 +344,35 @@ local channelingTicks = WoWWrath and {
 	[GetSpellName(234153)] = 5, -- drain life
 	[GetSpellName(198590)] = 5, -- drain soul
 	[GetSpellName(217979)] = 5, -- health funnel
+	[GetSpellName(196447)] = 15, -- channel demonfire
+	[GetSpellName(417537)] = 3, -- oblivion
 	-- druid
 	[GetSpellName(740)] = 4, -- tranquility
+	[GetSpellName(391528)] = 16, -- convoke the spirits
 	-- priest
 	[GetSpellName(64843)] = 4, -- divine hymn
 	[GetSpellName(15407)] = 6, -- mind flay
 	[GetSpellName(391403)] = 4, -- mind flay: insanity
 	[GetSpellName(47540)] = 3, -- penance
-	[GetSpellName(205065)] = 5, -- void torrent
 	[GetSpellName(64901)] = 5, -- symbol of hope
+	[GetSpellName(263165)] = 3, -- void torrent
+	[GetSpellName(400169)] = 3, -- dark reprimand
 	-- mage
 	[GetSpellName(5143)] = 5, -- arcane missiles
 	[GetSpellName(205021)] = 5, -- ray of frost
-	[GetSpellName(314791)] = 4, -- covenant: shifting power
+	[GetSpellName(12051)] = 6, -- evocation
+	[GetSpellName(198100)] = 8, -- kleptomania
+	[GetSpellName(382440)] = 4, -- shifting power
 	-- monk
 	[GetSpellName(117952)] = 4, -- crackling jade lightning
-	--[GetSpellName(191837)] = 3, -- essence font
 	[GetSpellName(115175)] = 8, -- soothing mist
+	[GetSpellName(443028)] = 4, -- celestial conduit
 	-- evoker
 	[GetSpellName(356995)] = 3, -- disintegrate
+	[GetSpellName(370960)] = 5, -- emerald communion
+	-- demon hunter
+	[GetSpellName(212084)] = 10, -- fel devastation
+	[GetSpellName(452486)] = 10, -- fel desolation
 } or {}
 
 
@@ -383,6 +393,15 @@ function Player:UpdateChannelingTicks()
 		if playerClass == "PRIEST" then
 			-- Castigation talent adds a tick to penance
 			channelingTicks[GetSpellName(47540)] = IsPlayerSpell(193134) and 4 or 3
+		elseif playerClass == "MAGE" then
+			-- Amplification talent adds 3 ticks to Arcane Missiles
+			channelingTicks[GetSpellName(5143)] = IsPlayerSpell(236628) and 8 or 5
+		elseif playerClass == "DRUID" then
+			-- Several talents remove 4 ticks from Convoke
+			channelingTicks[GetSpellName(391528)] = (IsPlayerSpell(391548) or IsPlayerSpell(393991) or IsPlayerSpell(393414) or IsPlayerSpell(393371)) and 12 or 16
+		elseif playerClass == "EVOKER" then
+			-- Azure Celerity adds a tick to Disintegrate
+			channelingTicks[GetSpellName(356995)] = IsPlayerSpell(1219723) and 4 or 3
 		end
 	end
 end


### PR DESCRIPTION
Add channeling ticks for several spells.
Remove Essence Font and unused versions of Void Torrent and Shifting Power.